### PR TITLE
Fixed Elo-calculations to use the class' stored elo-rankings

### DIFF
--- a/minimal_fighting_env/env/environment.py
+++ b/minimal_fighting_env/env/environment.py
@@ -506,7 +506,7 @@ class MinimalFightingEnv(gym.Env):
         if (self.p1_score < self.p2_score):
             winner = 1
         calc = eloCalculator()
-        new_ranks = calc.calculateRankChange(1500, 1500, winner)
+        new_ranks = calc.calculateRankChange(self.p1_elo, self.p2_elo, winner)
 
         print(f"New player 1 rank: {new_ranks[0]}")
         print(f"New player 2 rank: {new_ranks[1]}")


### PR DESCRIPTION
Fixed issue with elo rankings being calulcated from hardcoded elo-values. Now the env uses self.p1_elo and self.p2_elo to calculate the ranks.